### PR TITLE
Fix explanation about Datalog & Datomic

### DIFF
--- a/resources/toc_ja.md
+++ b/resources/toc_ja.md
@@ -1,6 +1,6 @@
 # Datalogを今日学ぼう！
 
-**Datalogを今日学ぼう！**は[Datalog](http://en.wikipedia.org/wiki/Datalog)の方言である[Datomic](http://datomic.com)について学ぶために用意された対話形式のチュートリアルです。Datalogは論理プログラミングを源流にもつ宣言的な**データベース問合せ言語**です。Datalogは[SQL](http://en.wikipedia.org/wiki/Sql)と同等の表現力を持ちます。
+**Datalogを今日学ぼう！**は[Datalog](http://en.wikipedia.org/wiki/Datalog)の[Datomic](http://datomic.com)方言について学ぶために用意された対話形式のチュートリアルです。Datalogは論理プログラミングを源流にもつ宣言的な**データベース問合せ言語**です。Datalogは[SQL](http://en.wikipedia.org/wiki/Sql)と同等の表現力を持ちます。
 
 Datomicは革新的なアーキテクチャを持ち、ユニークな特徴をユーザに提供する新しいデータベースです。Datomicの詳細については[http://datomic.com](http://datomic.com)を御覧ください。アーキテクチャの詳細については[InfoQの記事](https://www.infoq.com/jp/articles/Architecture-Datomic?utm_source=infoq_en&utm_medium=link_on_en_item&utm_campaign=item_in_other_langs)である程度述べられています。
 


### PR DESCRIPTION
冒頭説明で `Datalogの方言であるDatomic` とありますが、ここは原文で `the Datomic dialect of Datalog` となっているので「DatalogのDatomic方言」(もしくは少し言葉を補って「DatalogのDatomicにおける方言」?)などとするのが正確で良さそうな気がします。
現状では、Datomic自体がDatalogの方言であるかのように読めてしまいます😅